### PR TITLE
Added exception handling for Registration if no accounts created.

### DIFF
--- a/review_project/ratings/views.py
+++ b/review_project/ratings/views.py
@@ -75,7 +75,10 @@ class RegisterView(View):
 
     def get(self,request):
         logged_in=False
-        trial= (models.Control.objects.all().order_by('-updated_at'))[0]
+        try:
+            trial= (models.Control.objects.all().order_by('-updated_at'))[0]
+        except:
+            trial= (models.Control())
         registration=trial.RegistrationEnabled
         if registration:
             form_profile = self.form_class_profile(None)


### PR DESCRIPTION
Earlier if there were no accounts created, then clicking on <i>Register</i> gave an "index out of range error".